### PR TITLE
Removed "py" prefix from celery_broker_url

### DIFF
--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -21,7 +21,7 @@ simplefilter(action='ignore', category=FutureWarning)
 
 # url: "amqp://myuser:mypassword@localhost:5672/myvhost"
 celery_broker_url = (
-    f'pyamqp://'
+    f'amqp://'
     f'{auth.rabbitmq["username"]}:'
     f'{auth.rabbitmq["password"]}@'
     f'{auth.rabbitmq["host"]}/'


### PR DESCRIPTION
- Updated the celery_broker_url in tasks.py by removing the "py" prefix. Wasn't able to connect to celery with the "py" prefix however removing the "py" prefix fixed the issue.