### PR TITLE
Projection Updates

### DIFF
--- a/backend/dispatch.py
+++ b/backend/dispatch.py
@@ -94,6 +94,9 @@ class WebTaskConsumer(bootsteps.ConsumerStep):
 
             case "remove_group":
                 res = tasks.remove_group.signature(args=(), kwargs=kwargs)
+
+            case "remove_cluster":
+                res = tasks.remove_cluster.signature(args=(), kwargs=kwargs)
             
             case "remove_projection":
                 res = tasks.remove_projection.signature(args=(), kwargs=kwargs)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -2,7 +2,7 @@ import datetime
 from bson.objectid import ObjectId
 
 
-def create_group_object(color, included_documents, label, action, user_id, description, session_id, cluster_id=None):
+def create_group_object(color, included_documents, label, action, user_id, description, session_id, cluster_id=[]):
     obj = {
         "creation_time": datetime.datetime.utcnow(),
         "sessions": [session_id],

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -2,7 +2,7 @@ import datetime
 from bson.objectid import ObjectId
 
 
-def create_group_object(color, included_documents, label, action, user_id, description, session_id, cluster_id=ObjectId(str("0000"))):
+def create_group_object(color, included_documents, label, action, user_id, description, session_id, cluster_id=None):
     obj = {
         "creation_time": datetime.datetime.utcnow(),
         "sessions": [session_id],

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -2,7 +2,7 @@ import datetime
 from bson.objectid import ObjectId
 
 
-def create_group_object(color, included_documents, label, action, user_id, description, session_id, cluster_id=ObjectId(str("-1"))):
+def create_group_object(color, included_documents, label, action, user_id, description, session_id, cluster_id=ObjectId(str("0000"))):
     obj = {
         "creation_time": datetime.datetime.utcnow(),
         "sessions": [session_id],

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -2,10 +2,11 @@ import datetime
 from bson.objectid import ObjectId
 
 
-def create_group_object(color, included_documents, label, action, user_id, description, session_id):
+def create_group_object(color, included_documents, label, action, user_id, description, session_id, cluster_id=ObjectId(str("-1"))):
     obj = {
         "creation_time": datetime.datetime.utcnow(),
         "sessions": [session_id],
+        "cluster": cluster_id,
         "history": [
             {
                 "timestamp": datetime.datetime.utcnow(),

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1482,10 +1482,10 @@ def add_item(*args, **kwargs):
         if docset:
             logging.info(f"{type} with {oid} already in DB.")
             return # perhaps do something else before return like save?
+        
+        logging.info(f"keep going for now")
         # return anyways for now
-        logging.info(f"return anyways for now")
-
-        return
+        # return
     
     logging.info(f"Received {type} with OID {oid} and UID {uid}.")
 

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1478,7 +1478,7 @@ def add_item(*args, **kwargs):
 
     # If this already exists in the database, we can skip intitalization
     # Ignore this if type is cluster. Hacky solution to ignore copy_cluster
-    if ObjectId.is_valid(oid) & type != "Cluster":
+    if ObjectId.is_valid(oid) & (type != "Cluster"):
 
         docset = db.graph.find_one({"_id" : oid})
         if docset:

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1498,7 +1498,7 @@ def add_item(*args, **kwargs):
             if type == "Group":
                 res = add_group(db=database, color=color, label="new group", userid=userid, session_id=session_id, transaction_session=transaction_session)
             if type == "Cluster":
-                res = copy_cluster(db=database, session_id=session_id, cluster_id=oid, transaction_session=transaction_session)
+                res = copy_cluster(db=database, userid=userid, session_id=session_id, cluster_id=oid, transaction_session=transaction_session)
             
             message(userid, {
                 "oid": str(res),

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1545,7 +1545,7 @@ def add_item(*args, **kwargs):
             # If this already exists in the database, we can skip intitalization
             if ObjectId.is_valid(oid):
 
-                docset = db.groups.find_one({"cluster" : oid})
+                docset = db.groups.find_one({"cluster" : ObjectId(str(oid))})
                 if docset:
                     logging.info(f"{type} with {oid} already in DB.")
                     return # perhaps do something else before return like save?

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -730,7 +730,8 @@ def remove_group(*args, **kwargs):
     history_item["oid"] = group_id
 
     with transaction_session.start_transaction():
-        db.groups.update_one({"_id": group_id}, {"$pull": {"sessions": session_id}}, {"$push": {"cluster": None}})
+        db.groups.update_one({"_id": group_id}, {"$pull": {"sessions": session_id}})
+        db.groups.update_one({"_id": group_id}, {"$push": {"cluster": None}})
         utils.push_history(db, "sessions", session_id, history_item, transaction_session)
         utils.commit_with_retry(transaction_session)
         logging.info(f"Removed group {group_id} from session {session_id}.")

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1477,11 +1477,8 @@ def add_item(*args, **kwargs):
     oid  = kwargs["oid"]
 
     # If this already exists in the database, we can skip intitalization
-    if ObjectId.is_valid(oid):
-        
-        if type == "Cluster": 
-            logging.info(f"Continue for clusters")
-            pass
+    # Ignore this if type is cluster. Hacky solution to ignore copy_cluster
+    if ObjectId.is_valid(oid) & type != "Cluster":
 
         docset = db.graph.find_one({"_id" : oid})
         if docset:

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -730,7 +730,7 @@ def remove_group(*args, **kwargs):
     history_item["oid"] = group_id
 
     with transaction_session.start_transaction():
-        db.groups.update_one({"_id": group_id}, {"$pull": {"sessions": session_id}})
+        db.groups.update_one({"_id": group_id}, {"$pull": {"sessions": session_id}}, {"$push": {"cluster": None}})
         utils.push_history(db, "sessions", session_id, history_item, transaction_session)
         utils.commit_with_retry(transaction_session)
         logging.info(f"Removed group {group_id} from session {session_id}.")
@@ -1546,7 +1546,7 @@ def add_item(*args, **kwargs):
             docset = db.groups.find_one({"cluster" : ObjectId(str(oid))})
             if docset:
                 logging.info(f"Cluster has already been copied.")
-                res = docset.inserted_id
+                res = docset["_id"]
             else:
                 logging.info(f"Cluster has NOT been copied.")
                 res = copy_cluster(db=database, userid=userid, session_id=session_id, cluster_id=oid, transaction_session=transaction_session)

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1542,6 +1542,16 @@ def add_item(*args, **kwargs):
 
         case "Cluster":
 
+            # If this already exists in the database, we can skip intitalization
+            if ObjectId.is_valid(oid):
+
+                docset = db.groups.find_one({"cluster" : oid})
+                if docset:
+                    logging.info(f"{type} with {oid} already in DB.")
+                    return # perhaps do something else before return like save?
+            
+            logging.info(f"Received {type} with OID {oid} and UID {uid}.")
+
             res = copy_cluster(db=database, userid=userid, session_id=session_id, cluster_id=oid, transaction_session=transaction_session)
             
             message(userid, {

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1543,16 +1543,12 @@ def add_item(*args, **kwargs):
         case "Cluster":
 
             # If this already exists in the database, we can skip intitalization
-            if ObjectId.is_valid(oid):
-
-                docset = db.groups.find_one({"cluster" : ObjectId(str(oid))})
-                if docset:
-                    logging.info(f"{type} with {oid} already in DB.")
-                    return # perhaps do something else before return like save?
-            
-            logging.info(f"Received {type} with OID {oid} and UID {uid}.")
-
-            res = copy_cluster(db=database, userid=userid, session_id=session_id, cluster_id=oid, transaction_session=transaction_session)
+            docset = db.groups.find_one({"cluster" : ObjectId(str(oid))})
+            if docset:
+                logging.info(f"{type} with {oid} already in DB.")
+                res = docset
+            else:
+                res = copy_cluster(db=database, userid=userid, session_id=session_id, cluster_id=oid, transaction_session=transaction_session)
             
             message(userid, {
                 "oid": str(res),

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -762,11 +762,10 @@ def remove_cluster(*args, **kwargs):
     history_item["user"] = user_id
     history_item["clusters"].remove(c_id)
 
-    with transaction_session.start_transaction():
-        db.clusters.delete_one({"_id": c_id})
-        utils.push_history(db, "projections", p_id, history_item, transaction_session)
-        utils.commit_with_retry(transaction_session)
-        logging.info(f"Removed cluster {c_id} from projection {p_id}.")
+    db.clusters.delete_one({"_id": c_id})
+    utils.push_history(db, "projections", p_id, history_item, transaction_session)
+    utils.commit_with_retry(transaction_session)
+    logging.info(f"Removed cluster {c_id} from projection {p_id}.")
 
     return p_id
 

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1478,14 +1478,18 @@ def add_item(*args, **kwargs):
 
     # If this already exists in the database, we can skip intitalization
     if ObjectId.is_valid(oid):
+        
+        if type == "Cluster": 
+            logging.info(f"Continue for clusters")
+            pass
+
         docset = db.graph.find_one({"_id" : oid})
         if docset:
             logging.info(f"{type} with {oid} already in DB.")
             return # perhaps do something else before return like save?
         
-        logging.info(f"keep going for now")
-        # return anyways for now
-        # return
+        logging.info(f"return anyways for now")
+        return
     
     logging.info(f"Received {type} with OID {oid} and UID {uid}.")
 

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1480,9 +1480,11 @@ def add_item(*args, **kwargs):
     if ObjectId.is_valid(oid):
         docset = db.graph.find_one({"_id" : oid})
         if docset:
-            print(f"{type} with {oid} already in DB.")
+            logging.info(f"{type} with {oid} already in DB.")
             return # perhaps do something else before return like save?
         # return anyways for now
+        logging.info(f"return anyways for now")
+
         return
     
     logging.info(f"Received {type} with OID {oid} and UID {uid}.")

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -549,7 +549,9 @@ def copy_cluster(*args, **kwargs):
         cluster["history"][0]["label"], 
         "Copy cluster", 
         user_id, 
-        cluster["history"][0]["description"], session_id)
+        cluster["history"][0]["description"], 
+        session_id,
+        cluster_id=cluster_id)
 
     with transaction_session.start_transaction():
         group_res = db.groups.insert_one(obj, session=transaction_session)

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -551,7 +551,7 @@ def copy_cluster(*args, **kwargs):
         user_id, 
         cluster["history"][0]["description"], 
         session_id,
-        cluster_id=cluster_id)
+        cluster_id=[cluster_id])
 
     with transaction_session.start_transaction():
         group_res = db.groups.insert_one(obj, session=transaction_session)
@@ -731,8 +731,8 @@ def remove_group(*args, **kwargs):
 
     with transaction_session.start_transaction():
         db.groups.update_one({"_id": group_id}, {"$pull": {"sessions": session_id}})
-        db.groups.update_one({"_id": group_id}, {"$push": {"cluster": None}})
-        utils.push_history(db, "sessions", session_id, history_item, transaction_session)
+        db.groups.update_one({"_id": group_id}, {"$push": {"cluster": []}})
+        utils.push_history(db, "sessions", session_id, history_item, transaction_session) 
         utils.commit_with_retry(transaction_session)
         logging.info(f"Removed group {group_id} from session {session_id}.")
 
@@ -1544,7 +1544,7 @@ def add_item(*args, **kwargs):
         case "Cluster":
 
             # If this already exists in the database, we can skip intitalization
-            docset = db.groups.find_one({"cluster" : ObjectId(str(oid))})
+            docset = db.groups.find_one({"cluster" : [ObjectId(str(oid))]})
             if docset:
                 logging.info(f"Cluster has already been copied.")
                 res = docset["_id"]

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -730,8 +730,8 @@ def remove_group(*args, **kwargs):
     history_item["oid"] = group_id
 
     with transaction_session.start_transaction():
-        db.groups.update_one({"_id": group_id}, {"$pull": {"sessions": session_id}})
-        db.groups.update_one({"_id": group_id}, {"$push": {"cluster": []}})
+        db.groups.update_one({"_id": group_id}, {"$pull": {"sessions": session_id},})
+        db.groups.update_one({"_id": group_id}, {"$set": {"cluster": []}})
         utils.push_history(db, "sessions", session_id, history_item, transaction_session) 
         utils.commit_with_retry(transaction_session)
         logging.info(f"Removed group {group_id} from session {session_id}.")

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1545,9 +1545,10 @@ def add_item(*args, **kwargs):
             # If this already exists in the database, we can skip intitalization
             docset = db.groups.find_one({"cluster" : ObjectId(str(oid))})
             if docset:
-                logging.info(f"{type} with {oid} already in DB.")
-                res = docset
+                logging.info(f"Cluster has already been copied.")
+                res = docset.inserted_id
             else:
+                logging.info(f"Cluster has NOT been copied.")
                 res = copy_cluster(db=database, userid=userid, session_id=session_id, cluster_id=oid, transaction_session=transaction_session)
             
             message(userid, {

--- a/frontend/components/Accordion.tsx
+++ b/frontend/components/Accordion.tsx
@@ -49,7 +49,7 @@ export default function SimpleAccordion(props) {
         </AccordionSection>
         <AccordionSection
           compact={props.compact}
-          icon={wdefs["Projection Palette"].icon()}
+          icon={wdefs["Projections"].icon()}
           text="Projections"
         >
           <ProjectionPalette />

--- a/frontend/components/Cluster/Cluster.tsx
+++ b/frontend/components/Cluster/Cluster.tsx
@@ -19,7 +19,7 @@ export default function Cluster(props) {
         showClusterIcon = {false}
         showOrientIcon  = {true}
         showRemoveIcon  = {true}
-        cluster         = {cluster}
+        group           = {cluster}
       ></DocumentList>
     </div>
   );

--- a/frontend/components/Cluster/ClusterViewer.tsx
+++ b/frontend/components/Cluster/ClusterViewer.tsx
@@ -4,23 +4,15 @@ import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { Typography, Stack, List, ListItem, Divider } from "@mui/material";
+import { Typography, Stack, List, Divider } from "@mui/material";
 import WindowDefinitions from "@/components/WindowFolder/WindowDefinitions";
-import { useAppSelector, useAppDispatch } from "@/util/hooks";
+import { useAppSelector } from "@/util/hooks";
 import DocumentListItem from "@/components/Documents/DocumentListItem";
-import { CopyJson, CopyText, SaveDocx } from "@/components/GroupActions";
-import ButtonActions from "@/components/ButtonActions";
-
 
 export default function DocViewer(props) {
   const swr = useContext(swrContext);
   const { cluster } = swr.useSWRAbstract("cluster", `clusters/${props.id}`);
   const settings = useAppSelector((state) => state.windows.settings);
-
-  const data = cluster?.history[0].included_documents.map((p) => {
-    return [p, 1.0];
-  });
-
   const windowState = useAppSelector((state) => state.windows);
   const wdefs = WindowDefinitions(windowState);
 
@@ -36,7 +28,7 @@ export default function DocViewer(props) {
         id="panel3a-header"
       >
         <Typography noWrap align="left">
-          {wdefs["Cluster"].icon(cluster)}
+          {wdefs["Group"].icon(cluster)}
           {`${cluster?.history[0].label}`}
         </Typography>
       </AccordionSummary>

--- a/frontend/components/Cluster/ClusterViewer.tsx
+++ b/frontend/components/Cluster/ClusterViewer.tsx
@@ -1,0 +1,56 @@
+import React, { useContext } from "react";
+import { swrContext } from "@/util/swr";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { Typography, Stack, List, ListItem, Divider } from "@mui/material";
+import WindowDefinitions from "@/components/WindowFolder/WindowDefinitions";
+import { useAppSelector, useAppDispatch } from "@/util/hooks";
+import DocumentListItem from "@/components/Documents/DocumentListItem";
+import { CopyJson, CopyText, SaveDocx } from "@/components/GroupActions";
+import ButtonActions from "@/components/ButtonActions";
+
+
+export default function DocViewer(props) {
+  const swr = useContext(swrContext);
+  const { cluster } = swr.useSWRAbstract("cluster", `clusters/${props.id}`);
+  const settings = useAppSelector((state) => state.windows.settings);
+
+  const data = cluster?.history[0].included_documents.map((p) => {
+    return [p, 1.0];
+  });
+
+  const windowState = useAppSelector((state) => state.windows);
+  const wdefs = WindowDefinitions(windowState);
+
+  return (
+    <Accordion
+      defaultExpanded={settings.defaultExpanded}
+      disableGutters={true}
+      square={true}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls="panel3a-content"
+        id="panel3a-header"
+      >
+        <Typography noWrap align="left">
+          {wdefs["Cluster"].icon(cluster)}
+          {`${cluster?.history[0].label}`}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Stack spacing={1} sx={{ margin: "1em" }}>
+          <Typography variant="h5">{cluster?.history[0].label}</Typography>
+          <Divider></Divider>
+          <List>
+            {cluster?.history[0].included_documents.map((docid) => (
+              <DocumentListItem key={docid} id={docid}></DocumentListItem>
+            ))}
+          </List>
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/frontend/components/Cluster/Clusters.tsx
+++ b/frontend/components/Cluster/Clusters.tsx
@@ -55,7 +55,7 @@ export default function Clusters(props) {
           alignItems="center"
           style={{ margin: 0 }}
         >
-          <Tooltip title="Cluster on exisitng groups...">
+          <Tooltip title="Cluster on existing groups...">
           <IconButton onClick={runClusters}>
             <Diversity2Icon fontSize="small" />
           </IconButton>

--- a/frontend/components/Cluster/Clusters.tsx
+++ b/frontend/components/Cluster/Clusters.tsx
@@ -39,7 +39,7 @@ export default function Clusters(props) {
 
   const { groups } = swr.useSWRAbstract("groups", `sessions/${session_id}/groups`);
 
-
+  // TODO - cluster on flow inputs not all groups. 
   const runClusters = () => {
     client.cluster_by_groups(
       groups.map((g) => g._id),
@@ -48,7 +48,7 @@ export default function Clusters(props) {
     );
   };
 
-  const removeCluster = (c_id) => {client.remove_cluster(c_id)}
+  const removeCluster = (c_id) => {client.remove_cluster(c_id, p_id)}
 
   return (
     <>

--- a/frontend/components/Cluster/Clusters.tsx
+++ b/frontend/components/Cluster/Clusters.tsx
@@ -1,7 +1,6 @@
-import { useContext } from "react";
+import React, { useState, useContext } from "react";
 
-import { useAppSelector } from "@/util/hooks";
-import { RootState } from "@/stores/store";
+import { useAppSelector, useAppDispatch } from "@/util/hooks";
 import { swrContext } from "@/util/swr";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -11,33 +10,38 @@ import FolderIcon from "@mui/icons-material/Folder";
 import { StompContext } from "@/components/Stomp";
 import { IconButton, Tooltip } from "@mui/material";
 import {
-  Download as DownloadIcon,
   Delete as DeleteIcon,
-  ContentCopy as ContentCopyIcon,
-  CopyAll as CopyAllIcon,
   Diversity2 as Diversity2Icon,
 } from "@mui/icons-material";
 import Stack from "@mui/material/Stack";
 import Divider from "@mui/material/Divider";
 import { onDragStart } from "@/util/drag";
-
+import { setSelection } from "@/actions/windows";
 
 
 export default function Clusters(props) {
   const p_id = props.data;
   const session_id = useAppSelector((state) => state.activeSessionID.value);
-  const userid = useAppSelector((state) => state.activeSessionID.userid);
   const settings = useAppSelector((state) => state.windows.settings);
 
   const swr = useContext(swrContext);
   const client = useContext(StompContext);
+  const dispatch = useAppDispatch();
 
-  const { clusters } = swr.useSWRAbstract(
-    "clusters",
-    `projections/${p_id}/clusters`
-  );
-
+  const { clusters } = swr.useSWRAbstract("clusters", `projections/${p_id}/clusters`);
   const { groups } = swr.useSWRAbstract("groups", `sessions/${session_id}/groups`);
+
+  const [highlightedItem, setHighlightedItem] = useState(null);
+  
+  const handleItemClick = (c_id) => {
+    setHighlightedItem(c_id);
+    dispatch(
+      setSelection({
+        nodes: [{ id: c_id, data: { type: "Cluster" } }],
+        edges: [],
+      })
+    );
+  };
 
   // TODO - cluster on flow inputs not all groups. 
   const runClusters = () => {
@@ -71,15 +75,26 @@ export default function Clusters(props) {
         {clusters?.length !== 0 ? (
           <List>
             {clusters?.map((cluster) => {
+              const isHighlighted = cluster._id === highlightedItem;
               return (
                 <div
                   key={cluster._id}
-                  style={{ overflow: "auto", height: "100%" }}
+                  style={{
+                    overflow: "auto",
+                    position: "relative",
+                    borderBottom: "1px solid  #eceeee",
+                    paddingTop: "2px",
+                    paddingBottom: "3px",
+                    width: "100%",
+                    height: "100%",
+                    backgroundColor: isHighlighted ? "#EEEEEE" : "white",
+                  }}
                   draggable={true}
                   onDragStart={(e) => onDragStart(e, cluster._id, "Cluster")}
-                >
+                  onClick={() => handleItemClick(cluster._id)}
+                  >
                   <Stack
-                    sx={{ width: "100%" }}
+                    sx={{ width: "100%", }}
                     direction="row"
                     alignItems="center"
                     justifyContent="space-between"

--- a/frontend/components/Cluster/Clusters.tsx
+++ b/frontend/components/Cluster/Clusters.tsx
@@ -12,6 +12,7 @@ import { StompContext } from "@/components/Stomp";
 import { IconButton, Tooltip } from "@mui/material";
 import {
   Download as DownloadIcon,
+  Delete as DeleteIcon,
   ContentCopy as ContentCopyIcon,
   CopyAll as CopyAllIcon,
   Diversity2 as Diversity2Icon,
@@ -26,6 +27,7 @@ export default function Clusters(props) {
   const p_id = props.data;
   const session_id = useAppSelector((state) => state.activeSessionID.value);
   const userid = useAppSelector((state) => state.activeSessionID.userid);
+  const settings = useAppSelector((state) => state.windows.settings);
 
   const swr = useContext(swrContext);
   const client = useContext(StompContext);
@@ -45,6 +47,8 @@ export default function Clusters(props) {
       session_id
     );
   };
+
+  const removeCluster = (c_id) => {client.remove_cluster(c_id)}
 
   return (
     <>
@@ -74,15 +78,27 @@ export default function Clusters(props) {
                   draggable={true}
                   onDragStart={(e) => onDragStart(e, cluster._id, "Cluster")}
                 >
-                  <ListItem>
-                    <ListItemIcon>
-                      <FolderIcon sx={{ color: cluster.history[0].color }} />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={cluster.history[0].label}
-                      secondary={cluster.history[0].description}
-                    />
-                  </ListItem>
+                  <Stack
+                    sx={{ width: "100%" }}
+                    direction="row"
+                    alignItems="center"
+                    justifyContent="space-between"
+                  >
+                    <ListItem>
+                      <ListItemIcon>
+                        <FolderIcon sx={{ color: cluster.history[0].color }} />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={cluster.history[0].label}
+                        secondary={cluster.history[0].description}
+                      />
+                    </ListItem>
+                    <IconButton onClick={() => removeCluster(cluster._id)}>
+                      <DeleteIcon
+                        sx={[{"&:hover": {color: settings.color}}]}
+                      ></DeleteIcon>
+                    </IconButton>
+                  </Stack>
                 </div>
               );
             })}

--- a/frontend/components/Cluster/Projection.tsx
+++ b/frontend/components/Cluster/Projection.tsx
@@ -5,7 +5,6 @@ import React, { useState, useContext } from "react";
 import LoadingButton from "@mui/lab/LoadingButton";
 
 // custom components
-import DocumentList from "@/components/Documents/DocumentList";
 import Clusters from "@/components/Cluster/Clusters";
 
 // util

--- a/frontend/components/NotesViewer.tsx
+++ b/frontend/components/NotesViewer.tsx
@@ -5,10 +5,10 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Divider
 } from "@mui/material";
 import { swrContext } from "@/util/swr";
-
-import Notes from "@/components/Note";
+import WindowDefinitions from "@/components/WindowFolder/WindowDefinitions";
 import { useAppSelector } from "@/util/hooks";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
@@ -16,6 +16,8 @@ export default function NotesViewer(props) {
   const swr = useContext(swrContext);
   const { note } = swr.useSWRAbstract("note", `note/${props.id}`);
   const settings = useAppSelector((state) => state.windows.settings);
+  const windowState = useAppSelector((state) => state.windows);
+  const wdefs = WindowDefinitions(windowState);
 
   return (
     <Accordion
@@ -28,13 +30,19 @@ export default function NotesViewer(props) {
         aria-controls="panel3a-content"
         id="panel3a-header"
       >
-        <Typography variant="h5">{note?.history[0].label}</Typography>
+        <Typography noWrap align="left">
+          {wdefs["Note"].icon()}
+          {`${note?.history[0].label}`}
+        </Typography>
       </AccordionSummary>
       <AccordionDetails>
-        <Stack direction="column">
-          <Notes id={props.id}></Notes>
+        <Stack spacing={1} sx={{ margin: "1em" }}>
+          <Typography variant="h5">{note?.history[0].label}</Typography>
+          <Divider></Divider>
+          <Typography variant="small">{note?.history[0].content.blocks[0].text}</Typography>
         </Stack>
       </AccordionDetails>
     </Accordion>
+    
   );
 }

--- a/frontend/components/SelectionViewer.tsx
+++ b/frontend/components/SelectionViewer.tsx
@@ -5,6 +5,7 @@ import DocViewer from "@/components/DocViewer";
 import GroupViewer from "@/components/GroupViewer";
 import NotesViewer from "@/components/NotesViewer";
 import TeleoscopeViewer from "@/components/TeleoscopeViewer";
+import ClusterViewer from "@/components/Cluster/ClusterViewer";
 
 export default function SelectionViewer(props) {
   const selection = useAppSelector((state) => state.windows.selection);
@@ -28,6 +29,15 @@ export default function SelectionViewer(props) {
               key={node.id.split("%")[0]}
               id={node.id.split("%")[0]}
             ></GroupViewer>
+          );
+        }
+        if (node.data.type == "Cluster" && !props.noGroup) {
+          return (
+            <ClusterViewer
+              compact={true}
+              key={node.id.split("%")[0]}
+              id={node.id.split("%")[0]}
+            ></ClusterViewer>
           );
         }
         if (node.data.type == "Note") {

--- a/frontend/components/Stomp.ts
+++ b/frontend/components/Stomp.ts
@@ -351,6 +351,25 @@ export class Stomp {
   }
 
   /**
+   * Removes a cluster from a projection in MongoDB. 
+   *
+   * @param cluster_id
+   * @param projection_id
+   * @returns
+   */
+  remove_cluster(cluster_id: string, projection_id: string) {
+    const body = {
+      task: "remove_cluster",
+      args: {
+        cluster_id: cluster_id,
+        projection_id: projection_id,
+      },
+    };
+    this.publish(body);
+    return body;
+  }
+
+  /**
    * Removes a group from a session in MongoDB. Does not delete the group.
    *
    * @param teleoscope_id

--- a/frontend/components/TeleoscopeViewer.tsx
+++ b/frontend/components/TeleoscopeViewer.tsx
@@ -5,12 +5,15 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Divider,
+  List,
 } from "@mui/material";
 import { swrContext } from "@/util/swr";
 
 import { useAppSelector } from "@/util/hooks";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import DocumentListItem from "@/components/Documents/DocumentListItem";
+import WindowDefinitions from "@/components/WindowFolder/WindowDefinitions";
 
 export default function TeleoscopeViewer(props) {
   const swr = useContext(swrContext);
@@ -19,6 +22,8 @@ export default function TeleoscopeViewer(props) {
     `teleoscopes/${props.id}`
   );
   const settings = useAppSelector((state) => state.windows.settings);
+  const windowState = useAppSelector((state) => state.windows);
+  const wdefs = WindowDefinitions(windowState);
 
   return (
     <Accordion
@@ -31,13 +36,25 @@ export default function TeleoscopeViewer(props) {
         aria-controls="panel3a-content"
         id="panel3a-header"
       >
-        <Typography variant="h5">{teleoscope?.history[0].label}</Typography>
+        <Typography noWrap align="left">
+          {wdefs["Teleoscope"].icon(teleoscope)}
+          {`${teleoscope?.history[0].label}`}
+        </Typography>
       </AccordionSummary>
       <AccordionDetails>
-        <Stack direction="column">
+        {/* <Stack direction="column">
           {teleoscope?.history[0].rank_slice.map(([docid, rank]) => (
             <DocumentListItem key={docid} id={docid}></DocumentListItem>
           ))}
+        </Stack> */}
+        <Stack spacing={1} sx={{ margin: "1em" }}>
+          <Typography variant="h5">{teleoscope?.history[0].label}</Typography>
+          <Divider></Divider>
+          <List>
+            {teleoscope?.history[0].rank_slice.map(([docid, rank]) => (
+              <DocumentListItem key={docid} id={docid}></DocumentListItem>
+            ))}
+          </List>
         </Stack>
       </AccordionDetails>
     </Accordion>

--- a/frontend/components/WindowFolder/WindowDefinitions.tsx
+++ b/frontend/components/WindowFolder/WindowDefinitions.tsx
@@ -151,20 +151,6 @@ export default function WindowDefinitions(windowState) {
       icon:      () => <Diversity2Icon sx={style} fontSize="inherit" />,
       component: (w, id, color) => <ProjectionPalette id={id} windata={w} color={color} />,
     },
-    "Projection Palette": { // TODO REFACTOR
-      icon: () => {
-        return <Diversity2Icon sx={style} fontSize="inherit" />;
-      },
-      component: (w, id, color) => {
-        return <ProjectionPalette id={id} windata={w} color={color} />;
-      },
-      showWindow: false,
-      title: () => {
-        return `Projections`;
-      },
-      color: () => color,
-      tag: "projectionpalette",
-    },
     Search: {
       tag:       "search",
       type:      "Search",
@@ -196,14 +182,14 @@ export default function WindowDefinitions(windowState) {
       component: (w, id, color) => <Clusters id={id} windata={w} color={color} />,
     },
     Cluster: {
-      tag:       "cluster",
-      type:      "Cluster",
-      apipath:   "cluster",
-      nodetype:  WindowNode,      
-      title:     (d) => d?.history[0].label,
+      tag:       "group",
+      type:      "Group",
+      apipath:   "groups",
+      nodetype:  SourceNode,      
+      title:     (d) => `Group: ${d?.history[0].label}`,
       color:     (d) => d?.history[0].color,
-      icon:      (d) => <TopicIcon sx={{ color: d?.history[0].color }} fontSize="inherit"  />,
-      component: (w, id, color) => <Cluster id={id} windata={w} color={color} />,
+      icon:      (d) => <FolderIcon sx={{ color: d?.history[0].color }} fontSize="inherit"  />,
+      component: (w, id, color) => <Group id={id} windata={w} color={color} />,
     },
     Bookmarks: {
       tag:       "bookmarks",

--- a/frontend/components/WindowFolder/WindowDefinitions.tsx
+++ b/frontend/components/WindowFolder/WindowDefinitions.tsx
@@ -37,7 +37,6 @@ import Teleoscope from "@/components/Teleoscope";
 import Search from "@/components/Search";
 import Groups from "@/components/Groups";
 import Clusters from "@/components/Cluster/Clusters";
-import Cluster from "@/components/Cluster/Cluster";
 import Projection from "@/components/Cluster/Projection";
 import ProjectionPalette from "@/components/Cluster/ProjectionPalette";
 import Notes from "@/components/Notes";
@@ -178,16 +177,6 @@ export default function WindowDefinitions(windowState) {
       color:     () => color,
       icon:      () => <Diversity2Icon sx={style} fontSize="inherit" />,
       component: (w, id, color) => <Clusters id={id} windata={w} color={color} />,
-    },
-    Cluster: {
-      tag:       "group",
-      type:      "Group",
-      apipath:   "groups",
-      nodetype:  SourceNode,      
-      title:     (d) => `Group: ${d?.history[0].label}`,
-      color:     (d) => d?.history[0].color,
-      icon:      (d) => <FolderIcon sx={{ color: d?.history[0].color }} fontSize="inherit"  />,
-      component: (w, id, color) => <Group id={id} windata={w} color={color} />,
     },
     Bookmarks: {
       tag:       "bookmarks",

--- a/frontend/components/WindowFolder/WindowFactory.tsx
+++ b/frontend/components/WindowFolder/WindowFactory.tsx
@@ -27,9 +27,9 @@ export default function WindowFactory(props) {
     teleoscopepalette: "teleoscopes",
     projection: "projections",
     projectionpalette: "projectionpalette",
+    clusters: "clusters",
     search: "search",
     groups: "groups",
-    cluster: "groups",
     operation: "operation",
     intersection: "intersection",
     ...paths

--- a/frontend/components/WindowFolder/WindowFactory.tsx
+++ b/frontend/components/WindowFolder/WindowFactory.tsx
@@ -29,7 +29,7 @@ export default function WindowFactory(props) {
     projectionpalette: "projectionpalette",
     search: "search",
     groups: "groups",
-    cluster: "clusters",
+    cluster: "groups",
     operation: "operation",
     intersection: "intersection",
     ...paths


### PR DESCRIPTION
- dragging out a cluster from projection copies as a group (using middleware schema)
- dragging out a cluster that has already been copied will simply reference the existing copy
- new field added to group objects called `cluster`, this denotes the cluster that the group is a copy of (if it is the case)
- added a 'cluster reader' to the accordion. clicking on a cluster in a projection now displays all the docs in said cluster on the accordion. like document reader
- added a delete button to projection palette that deletes unwanted clusters