### PR TITLE
fix: handle Git LFS pointer stubs in demo data download

### DIFF
--- a/ansible/seed-demo.yaml
+++ b/ansible/seed-demo.yaml
@@ -25,12 +25,19 @@
     - ./vars/infra-outputs.yaml
 
   tasks:
-    - name: Install python3-venv system package
+    - name: Install system packages required for seeding
       ansible.builtin.apt:
-        name: python3-venv
+        name:
+          - python3-venv
+          - git-lfs       # needed to fetch real LFS objects (not pointer stubs)
         state: present
         update_cache: false
       become: true
+
+    - name: Configure git-lfs for the remote user
+      ansible.builtin.command:
+        cmd: git lfs install
+      changed_when: false
 
     - name: Create seed virtualenv and install Python dependencies
       ansible.builtin.pip:

--- a/scripts/download-demo-data.sh
+++ b/scripts/download-demo-data.sh
@@ -38,6 +38,17 @@ info "Cloning (shallow, depth=1)..."
 git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$TMP_DIR"
 ok "Clone finished"
 
+# Resolve Git LFS objects so large files aren't left as pointer stubs.
+# git-lfs must be installed (sudo apt install git-lfs && git lfs install).
+if git -C "$TMP_DIR" lfs --version &>/dev/null 2>&1; then
+  info "Resolving Git LFS objects (git lfs pull)..."
+  git -C "$TMP_DIR" lfs pull
+  ok "Git LFS objects resolved"
+else
+  warn "git-lfs not found — large files may be Git LFS pointer stubs, not real data."
+  warn "Install git-lfs: sudo apt install git-lfs && git lfs install && re-run this script."
+fi
+
 info "Copying into $DATA_DIR (excluding .git)..."
 if command -v rsync &>/dev/null; then
   rsync -a --exclude='.git' "$TMP_DIR/" "$DATA_DIR/"

--- a/scripts/seed-demo-corpus.py
+++ b/scripts/seed-demo-corpus.py
@@ -196,9 +196,31 @@ def _fmt_elapsed(seconds: float) -> str:
     return f"{seconds:.1f}s"
 
 
+_GIT_LFS_POINTER_HEADER = b"version https://git-lfs.github.com/spec/v1"
+
+
+def _is_git_lfs_pointer(path: Path) -> bool:
+    """Return True if *path* is a Git LFS pointer (real file was never fetched)."""
+    try:
+        with open(path, "rb") as f:
+            return f.read(len(_GIT_LFS_POINTER_HEADER)) == _GIT_LFS_POINTER_HEADER
+    except OSError:
+        return False
+
+
 def demo_document_sources_present() -> bool:
     jsonl_path = DATA_DIR / "documents.jsonl"
-    return DOCUMENTS_7Z.exists() or jsonl_path.is_file()
+    if DOCUMENTS_7Z.exists():
+        if _is_git_lfs_pointer(DOCUMENTS_7Z):
+            log(
+                f"{DOCUMENTS_7Z.name} is a Git LFS pointer — the real archive was not fetched. "
+                "Install git-lfs on the host (sudo apt install git-lfs && git lfs install) "
+                "and re-run, or delete the pointer file and re-run with --download.",
+                "WARN",
+            )
+            return False  # treat as absent so ensure_demo_data_files triggers a fresh download
+        return True
+    return jsonl_path.is_file()
 
 
 def find_parquet_dir() -> Path | None:


### PR DESCRIPTION
documents.jsonl.7z on the remote host was a Git LFS pointer (2-line text stub) rather than the real archive, because git clone was run without git-lfs installed.  py7zr then rejected it with "not a 7z file".

Three-part fix:
- ansible/seed-demo.yaml: install git-lfs via apt and run `git lfs install` before the seed task so subsequent clones resolve LFS objects
- scripts/download-demo-data.sh: run `git lfs pull` after clone when git-lfs is available; warn clearly when it is not
- scripts/seed-demo-corpus.py: detect Git LFS pointer headers in the 7z file and treat the file as absent so ensure_demo_data_files triggers a fresh download instead of attempting (and failing) to extract a stub

https://claude.ai/code/session_01KZwM9qR1LULaetALbrVAKV