### PR TITLE
fix: stream documents from 7z in batches instead of loading all into RAM

### DIFF
--- a/scripts/demo_7z_jsonl.py
+++ b/scripts/demo_7z_jsonl.py
@@ -13,7 +13,7 @@ import json
 import tempfile
 import time
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Generator
 
 
 def extract_jsonl_rows_from_7z(
@@ -22,6 +22,21 @@ def extract_jsonl_rows_from_7z(
     log: Callable[[str, str], None] | None = None,
 ) -> list[dict]:
     """Return parsed JSON objects, one per non-empty line, for all ``*.jsonl`` members."""
+    return list(iter_jsonl_rows_from_7z(archive_path, log=log))
+
+
+def iter_jsonl_rows_from_7z(
+    archive_path: Path,
+    *,
+    log: Callable[[str, str], None] | None = None,
+) -> Generator[dict, None, None]:
+    """Yield parsed JSON objects one at a time from all ``*.jsonl`` members of a ``.7z``.
+
+    Extracts to a temporary directory on disk then streams line-by-line so
+    only one batch's worth of rows needs to be in memory at a time.  The
+    temporary directory is cleaned up when the generator is closed or
+    garbage-collected.
+    """
     try:
         import py7zr
     except ImportError as e:
@@ -38,37 +53,43 @@ def extract_jsonl_rows_from_7z(
         if log:
             log(msg, level)
 
-    rows: list[dict] = []
     _log(f"Opening 7z archive: {archive_path}", "INFO")
-    with SevenZipFile(archive_path, mode="r") as arc:
-        names = arc.getnames() if hasattr(arc, "getnames") else arc.namelist()
-        targets = [n for n in names if str(n).endswith(".jsonl")]
-        _log(f"JSONL members ({len(targets)}): {targets}", "INFO")
-        if not targets:
-            _log("No .jsonl files in archive.", "WARN")
-            return rows
-
-        t0 = time.perf_counter()
-        with tempfile.TemporaryDirectory() as tmpd:
-            tmp = Path(tmpd)
+    tmpdir = tempfile.TemporaryDirectory()
+    try:
+        tmp = Path(tmpdir.name)
+        with SevenZipFile(archive_path, mode="r") as arc:
+            names = arc.getnames() if hasattr(arc, "getnames") else arc.namelist()
+            targets = [n for n in names if str(n).endswith(".jsonl")]
+            _log(f"JSONL members ({len(targets)}): {targets}", "INFO")
+            if not targets:
+                _log("No .jsonl files in archive.", "WARN")
+                return
+            t0 = time.perf_counter()
             arc.extract(path=tmp, targets=targets)
-            for jsonl_path in sorted(tmp.rglob("*.jsonl")):
-                rel = jsonl_path.relative_to(tmp)
-                for raw_line in jsonl_path.read_text(encoding="utf-8").splitlines():
+
+        n_rows = 0
+        n_bad = 0
+        for jsonl_path in sorted(tmp.rglob("*.jsonl")):
+            rel = jsonl_path.relative_to(tmp)
+            with open(jsonl_path, encoding="utf-8") as f:
+                for raw_line in f:
                     line = raw_line.strip()
                     if not line:
                         continue
                     try:
-                        rows.append(json.loads(line))
+                        yield json.loads(line)
+                        n_rows += 1
                     except json.JSONDecodeError as e:
                         _log(f"Skip bad JSON line in {rel}: {e}", "WARN")
+                        n_bad += 1
 
-        def _fmt_elapsed(seconds: float) -> str:
-            return f"{seconds / 60:.1f}m" if seconds >= 120 else f"{seconds:.1f}s"
+        def _fmt(s: float) -> str:
+            return f"{s / 60:.1f}m" if s >= 120 else f"{s:.1f}s"
 
         _log(
-            f"Parsed {len(rows):,} lines from 7z JSONL in {_fmt_elapsed(time.perf_counter() - t0)}.",
+            f"Streamed {n_rows:,} rows from 7z JSONL in {_fmt(time.perf_counter() - t0)}"
+            + (f" ({n_bad} bad lines skipped)" if n_bad else "") + ".",
             "OK",
         )
-
-    return rows
+    finally:
+        tmpdir.cleanup()

--- a/scripts/seed-demo-corpus.py
+++ b/scripts/seed-demo-corpus.py
@@ -556,61 +556,173 @@ def load_jsonl_uncompressed(path: Path) -> list[dict]:
 
 
 def load_documents_jsonl() -> list[dict]:
+    """Load all documents into memory.  Prefer iter_documents_jsonl() for large corpora."""
+    return list(iter_documents_jsonl())
+
+
+def iter_documents_jsonl():
+    """Yield raw JSONL rows one at a time.  Peak RAM = O(1 row), not O(all rows)."""
     jsonl_path = DATA_DIR / "documents.jsonl"
     if DOCUMENTS_7Z.exists():
         log(f"Document source: compressed archive {DOCUMENTS_7Z}", "INFO")
-        return extract_jsonl_from_7z(DOCUMENTS_7Z)
+        _scripts = str(Path(__file__).resolve().parent)
+        if _scripts not in sys.path:
+            sys.path.insert(0, _scripts)
+        from demo_7z_jsonl import iter_jsonl_rows_from_7z
+        yield from iter_jsonl_rows_from_7z(DOCUMENTS_7Z, log=log)
+        return
     if jsonl_path.exists():
-        log(f"Reading uncompressed JSONL: {jsonl_path}", "INFO")
-        t0 = time.perf_counter()
-        rows = load_jsonl_uncompressed(jsonl_path)
-        log(
-            f"Loaded {len(rows):,} rows from JSONL in {_fmt_elapsed(time.perf_counter() - t0)}.",
-            "OK",
-        )
-        return rows
+        log(f"Document source: uncompressed JSONL {jsonl_path}", "INFO")
+        with open(jsonl_path, encoding="utf-8") as f:
+            for raw_line in f:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError as e:
+                    log(f"Skip bad JSON line: {e}", "WARN")
+        return
     raise FileNotFoundError(
         f"Neither {DOCUMENTS_7Z} nor {jsonl_path} found after fetch step. "
         "Check TELEOSCOPE_DATA_DIR or run ./scripts/download-demo-data.sh."
     )
 
 
+def _row_to_mongo_doc(row: dict, workspace_id: ObjectId) -> dict | None:
+    """Convert a single raw JSONL row to a MongoDB document dict, or None if the row is empty."""
+    title = (row.get("title") or "").strip() or "Untitled"
+    text = (row.get("text") or "").strip()
+    if not text and not title:
+        return None
+    meta = {}
+    for k, v in row.items():
+        if k in ("title", "text", "id"):
+            continue
+        if v is None:
+            continue
+        if isinstance(v, (str, int, float, bool)):
+            meta[k] = v
+        elif isinstance(v, (list, dict)):
+            try:
+                json.dumps(v)
+                meta[k] = v
+            except (TypeError, ValueError):
+                pass
+    source_id = row.get("id")
+    if source_id is not None:
+        meta["source_id"] = str(source_id)
+    return {
+        "text": text[:1_000_000],
+        "title": title[:2048],
+        "relationships": {},
+        "metadata": meta,
+        "workspace": workspace_id,
+        "state": {"vectorized": True},
+    }
+
+
 def mongo_docs_from_rows(rows: list[dict], workspace_id: ObjectId) -> list[dict]:
+    """Build a list of MongoDB documents from all rows.  Kept for backward compatibility;
+    prefer stream_insert_documents() for large corpora to avoid loading all rows into RAM."""
     docs = []
     row_iter = rows
     if _seed_use_progress and len(rows) >= 8000:
         row_iter = _pbar(rows, total=len(rows), desc="Build Mongo payloads", unit="row")
     for row in row_iter:
-        title = (row.get("title") or "").strip() or "Untitled"
-        text = (row.get("text") or "").strip()
-        if not text and not title:
-            continue
-        meta = {}
-        for k, v in row.items():
-            if k in ("title", "text", "id"):
-                continue
-            if v is None:
-                continue
-            if isinstance(v, (str, int, float, bool)):
-                meta[k] = v
-            elif isinstance(v, (list, dict)):
-                try:
-                    json.dumps(v)
-                    meta[k] = v
-                except (TypeError, ValueError):
-                    pass
-        source_id = row.get("id")
-        if source_id is not None:
-            meta["source_id"] = str(source_id)
-        docs.append({
-            "text": text[:1_000_000],
-            "title": title[:2048],
-            "relationships": {},
-            "metadata": meta,
-            "workspace": workspace_id,
-            "state": {"vectorized": True},
-        })
+        doc = _row_to_mongo_doc(row, workspace_id)
+        if doc is not None:
+            docs.append(doc)
     return docs
+
+
+def stream_insert_documents(
+    client: MongoClient,
+    workspace_id: ObjectId,
+    row_iter,
+    batch_size: int = BATCH_INSERT,
+) -> tuple[MongoClient, list[ObjectId]]:
+    """Stream-insert documents from *row_iter* one batch at a time.
+
+    Peak RAM is O(batch_size) — only one batch of raw rows + one batch of
+    transformed docs is live at any moment.  Avoids the OOM that occurs when
+    load_documents_jsonl() + mongo_docs_from_rows() hold two full copies of
+    the entire corpus in memory simultaneously.
+
+    Resume: counts existing workspace documents before starting; skips that
+    many rows from the front of *row_iter* so a restart after a crash picks up
+    where it left off.
+    """
+    max_attempts = max(1, int(os.environ.get("SEED_MONGO_BATCH_RETRIES", "12")))
+    t_all = time.perf_counter()
+    per_batch_logs = not _seed_use_progress
+
+    db = client[MONGODB_DATABASE]
+    inserted: list[ObjectId] = list(_mongo_workspace_doc_ids(db, workspace_id))
+    n_skip = len(inserted)
+    if n_skip:
+        log(
+            f"Stream-insert resume: {n_skip:,} documents already present for workspace; "
+            f"skipping first {n_skip:,} source rows.",
+            "WARN",
+        )
+
+    bi = 0
+    batch: list[dict] = []
+    skipped = 0
+
+    for raw_row in row_iter:
+        if skipped < n_skip:
+            skipped += 1
+            continue
+        doc = _row_to_mongo_doc(raw_row, workspace_id)
+        if doc is None:
+            continue
+        batch.append(doc)
+        if len(batch) < batch_size:
+            continue
+        # Batch is full — insert with retry.
+        bi += 1
+        t0 = time.perf_counter()
+        for attempt in range(max_attempts):
+            try:
+                db = client[MONGODB_DATABASE]
+                result = db.documents.insert_many(batch, ordered=False)
+                inserted.extend(result.inserted_ids)
+                break
+            except Exception as e:
+                if not _mongo_seed_transient(e) or attempt + 1 >= max_attempts:
+                    raise
+                log(f"Batch {bi}: transient error ({e!s}); reconnecting (attempt {attempt + 2}/{max_attempts})…", "WARN")
+                time.sleep(min(30.0, 1.5 ** attempt))
+                try:
+                    client.close()
+                except Exception:
+                    pass
+                client = mongo_client_for_seed()
+                db = client[MONGODB_DATABASE]
+        dt = time.perf_counter() - t0
+        if per_batch_logs:
+            lo, hi = len(inserted) - len(batch) + 1, len(inserted)
+            log(f"Batch {bi}: documents {lo:,}–{hi:,} ({len(batch):,} inserted, {dt:.2f}s, {len(batch)/dt:,.0f} docs/s)", "OK")
+        batch = []  # release memory for this batch
+
+    # Final partial batch.
+    if batch:
+        bi += 1
+        db = client[MONGODB_DATABASE]
+        result = db.documents.insert_many(batch, ordered=False)
+        inserted.extend(result.inserted_ids)
+        if per_batch_logs:
+            log(f"Batch {bi} (final): {len(batch):,} documents inserted.", "OK")
+        batch = []
+
+    log(
+        f"Stream-insert complete: {len(inserted):,} total documents in {bi} batch(es), "
+        f"{_fmt_elapsed(time.perf_counter() - t_all)} elapsed.",
+        "OK",
+    )
+    return client, inserted
 
 
 def insert_documents_batched(
@@ -1159,11 +1271,6 @@ def seed(
         need_documents=True,
         need_parquet=need_parquet,
     )
-    log_section("Source documents (7z or JSONL)")
-    log("Loading documents from 7z/JSONL...", "INFO")
-    raw_rows = load_documents_jsonl()
-    log(f"Loaded {len(raw_rows):,} raw rows from source.", "OK")
-
     log_section("MongoDB")
     client = mongo_client_for_seed()
     db = client[MONGODB_DATABASE]
@@ -1219,18 +1326,6 @@ def seed(
         })
         log(f"Created team={team_id}, workspace={workspace_id}, workflow={workflow_id}", "OK")
 
-    t_build = time.perf_counter()
-    docs = mongo_docs_from_rows(raw_rows, workspace_id)
-    log(
-        f"Built {len(docs):,} Mongo document payloads from {len(raw_rows):,} raw rows "
-        f"in {_fmt_elapsed(time.perf_counter() - t_build)}.",
-        "INFO",
-    )
-    if not docs:
-        log("No documents to insert.", "WARN")
-        client.close()
-        return
-
     if workspace_documents_only:
         if not keep_text_index:
             log(
@@ -1256,7 +1351,13 @@ def seed(
         )
         wipe_documents_collection(db)
 
-    client, inserted_ids = insert_documents_batched(client, workspace_id, docs)
+    # Stream-insert: read one batch from disk → transform → insert → free → repeat.
+    # Peak RAM = O(batch_size) ≈ a few MB, not O(347 k docs) ≈ 4–5 GB.
+    log_section("Source documents (7z or JSONL) — streaming batch insert")
+    log("Streaming documents from source into MongoDB (no full-corpus load into RAM)…", "INFO")
+    client, inserted_ids = stream_insert_documents(
+        client, workspace_id, iter_documents_jsonl(), batch_size=BATCH_INSERT
+    )
     db = client[MONGODB_DATABASE]
     log(f"Inserted {len(inserted_ids):,} documents into workspace {workspace_id}.", "OK")
 


### PR DESCRIPTION
Root cause of the overnight instance crash: the seed pipeline held two full copies of the 347 k document corpus in memory at the same time — load_documents_jsonl() returned a list[dict] of all raw rows, then mongo_docs_from_rows() built a second list[dict] of all transformed docs, and only then did insert_documents_batched() start inserting in chunks of 500. At ~6–8 KB per Python dict that is 4–5 GB on top of the ~1.5 GB Docker stack, easily saturating the t3.large's 8 GB and triggering the OOM killer.

Changes:
- demo_7z_jsonl.py: add iter_jsonl_rows_from_7z() generator — extracts to a temp dir on disk (same as before), then yields rows one at a time instead of accumulating them in a list.  extract_jsonl_rows_from_7z() is kept for backward compatibility and now just wraps list(iter_...).
- seed-demo-corpus.py:
  - Add iter_documents_jsonl() generator (7z or uncompressed JSONL path)
  - Add _row_to_mongo_doc() single-row transform extracted from mongo_docs_from_rows() (kept for backward compat)
  - Add stream_insert_documents() — reads from a row iterator, transforms and inserts one batch at a time; peak RAM = O(batch_size) ≈ a few MB
  - Replace the three-step load-all / transform-all / insert pipeline in seed() with a single stream_insert_documents() call feeding iter_documents_jsonl()

https://claude.ai/code/session_01KZwM9qR1LULaetALbrVAKV