### PR TITLE
fix: remove disown from background start tasks (not available in /bin…

### DIFF
--- a/ansible/seed-demo.yaml
+++ b/ansible/seed-demo.yaml
@@ -151,7 +151,6 @@
             fi
             rm -f /tmp/seed-mongo.rc /tmp/seed-demo-mongo.log
             nohup sh -c '{{ remote_prefix }}/{{ ansible_user }}/Teleoscope/.venv-seed/bin/python scripts/seed-demo-corpus.py --no-progress --workspace-documents-only > /tmp/seed-demo-mongo.log 2>&1; echo $? > /tmp/seed-mongo.rc' >/dev/null 2>&1 &
-            disown $!
           args:
             chdir: "{{ remote_prefix }}/{{ ansible_user }}/Teleoscope"
           environment:
@@ -208,7 +207,6 @@
             fi
             rm -f /tmp/seed-zilliz.rc /tmp/seed-demo-zilliz.log
             nohup sh -c '{{ remote_prefix }}/{{ ansible_user }}/Teleoscope/.venv-seed/bin/python scripts/seed-demo-corpus.py --no-progress --milvus-only > /tmp/seed-demo-zilliz.log 2>&1; echo $? > /tmp/seed-zilliz.rc' >/dev/null 2>&1 &
-            disown $!
           args:
             chdir: "{{ remote_prefix }}/{{ ansible_user }}/Teleoscope"
           environment:


### PR DESCRIPTION
…/sh)

Ansible's shell module uses /bin/sh by default; disown is a bash built-in and returns exit code 127 ("command not found") in sh, causing the start task to fail immediately.  This sent execution straight to the always block before the Python script had written anything meaningful to the log.

nohup alone is sufficient: it redirects SIGHUP so the process survives SSH disconnection without needing disown.

https://claude.ai/code/session_01KZwM9qR1LULaetALbrVAKV