### PR TITLE
Improve MongoDB replica set configuration and Worker EC2 pre-warming

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,11 +49,36 @@ services:
     restart: "no"
     environment:
       MONGODB_ADMIN_PASSWORD: ${MONGODB_ADMIN_PASSWORD:-admin_password}
+      # MONGODB_RS_HOST controls the replica set member hostname advertised to clients.
+      # Default 'mongodb' works inside Docker (inter-container DNS).
+      # For external / SSH-tunnel inspection set this to the host's IP or hostname so
+      # MongoDB Compass / mongosh can resolve it:
+      #   MONGODB_RS_HOST=<server-ip>  # e.g. 1.2.3.4 or my-server.example.com
+      # When connecting via SSH tunnel use directConnection=true instead:
+      #   mongodb://admin:<pw>@localhost:27017/admin?authSource=admin&directConnection=true
+      MONGODB_RS_HOST: ${MONGODB_RS_HOST:-mongodb}
     entrypoint: ["/bin/bash", "-eu", "-c"]
     command:
       - |
         echo "mongodb-init: ensuring replica set rs0 (Mongo already passed health: admin ping)..."
-        mongosh --host mongodb --username admin --password "$MONGODB_ADMIN_PASSWORD" --authenticationDatabase admin --quiet --eval "try { rs.status(); quit(0); } catch (e) { rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: 'mongodb:27017' }] }); quit(0); }"
+        RS_HOST="${MONGODB_RS_HOST:-mongodb}"
+        mongosh --host mongodb --username admin --password "$MONGODB_ADMIN_PASSWORD" --authenticationDatabase admin --quiet --eval "
+          try {
+            var s = rs.status();
+            var cur = s.members[0].name;
+            var want = '${RS_HOST}:27017';
+            if (cur !== want) {
+              print('mongodb-init: reconfiguring RS member from ' + cur + ' to ' + want);
+              var cfg = rs.conf();
+              cfg.members[0].host = want;
+              rs.reconfig(cfg, { force: true });
+            }
+            quit(0);
+          } catch (e) {
+            rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: '${RS_HOST}:27017' }] });
+            quit(0);
+          }
+        "
         echo "mongodb-init: done"
 
   rabbitmq:
@@ -154,6 +179,7 @@ services:
       RABBITMQ_HOST: rabbitmq
       RABBITMQ_PORT: 5672
       RABBITMQ_VHOST: /
+      RABBITMQ_DISPATCH_QUEUE: teleoscope-dispatch
       RABBITMQ_QUEUE: teleoscope-dispatch
       TELEOSCOPE_BASE_URL: ${TELEOSCOPE_BASE_URL:-http://localhost:3000}
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}

--- a/teleoscope.ca/src/app/api/demo/bootstrap/route.ts
+++ b/teleoscope.ca/src/app/api/demo/bootstrap/route.ts
@@ -11,6 +11,7 @@ import { connect } from '@/lib/lucia';
 import { Teams } from '@/types/teams';
 import { Workspaces } from '@/types/workspaces';
 import { isDemoUserById, getDemoCorpusWorkspaceIdAsync } from '@/lib/demoMode';
+import send from '@/lib/amqp';
 
 async function getDefaultWorkspaceId(userId: string): Promise<string | null> {
     const mongoClient = await client();
@@ -56,6 +57,12 @@ export async function POST() {
                 { status: 500 }
             );
         }
+
+        // Pre-warm the Worker EC2: publish a ping task so the monitor sees a
+        // non-zero queue depth and starts the instance immediately.  By the time
+        // the user triggers a real operation (rank, search, etc.) the instance
+        // will already be booting rather than cold-starting on first use.
+        send('ping', {}).catch(() => { /* non-fatal — monitor will catch up */ });
 
         const response = NextResponse.json({
             workspace_id: workspaceId,

--- a/teleoscope.ca/src/lib/amqp.ts
+++ b/teleoscope.ca/src/lib/amqp.ts
@@ -10,10 +10,16 @@ const database = process.env.MONGODB_DATABASE
 
 const rabbitMqUrl = `amqp://${username}:${password}@${host}:${port}/${vhost}`
 
+// RABBITMQ_DISPATCH_QUEUE is the canonical name used by the backend monitor and
+// workers. RABBITMQ_QUEUE is an older alias kept for backward compatibility.
+const DISPATCH_QUEUE =
+    process.env.RABBITMQ_DISPATCH_QUEUE ||
+    process.env.RABBITMQ_QUEUE ||
+    'teleoscope-dispatch';
 
 async function send(task: string, args: any) {
-    const queue = `${process.env.RABBITMQ_QUEUE}`;
-    
+    const queue = DISPATCH_QUEUE;
+
     const kwargs = {
         ...args,
         database: database

--- a/teleoscope.ca/src/lib/demoMode.ts
+++ b/teleoscope.ca/src/lib/demoMode.ts
@@ -50,10 +50,13 @@ export async function getDemoCorpusWorkspaceIdAsync(): Promise<string | null> {
         const workspace = await db
             .collection<Workspaces>('workspaces')
             .findOne({ label: DEMO_CORPUS_WORKSPACE_LABEL }, { projection: { _id: 1 } });
+        // Only cache definitive results (found or genuinely absent).
+        // Transient DB errors must not poison the cache — leave it undefined so
+        // the next request retries rather than permanently returning null.
         demoCorpusWorkspaceIdCache = workspace?._id?.toString() ?? null;
         return demoCorpusWorkspaceIdCache;
     } catch {
-        demoCorpusWorkspaceIdCache = null;
+        // Don't update the cache on transient errors so the next call retries.
         return null;
     }
 }


### PR DESCRIPTION
## Summary
This PR enhances MongoDB replica set management and adds Worker EC2 pre-warming functionality to improve the demo bootstrap experience and support external MongoDB connections.

## Key Changes

- **MongoDB Replica Set Host Configuration**: Added `MONGODB_RS_HOST` environment variable to allow configuring the hostname advertised by MongoDB replica set members. This enables external connections via SSH tunnels or direct IP access while maintaining backward compatibility with the default Docker internal hostname.

- **Dynamic Replica Set Reconfiguration**: Enhanced the MongoDB initialization script to detect and automatically reconfigure replica set members when the advertised hostname changes, preventing connection issues when the host configuration is updated.

- **Worker EC2 Pre-warming**: Added a ping task published during demo bootstrap to trigger Worker EC2 instance startup before users perform actual operations, reducing cold-start latency on first use.

- **RabbitMQ Queue Naming**: Introduced `RABBITMQ_DISPATCH_QUEUE` as the canonical queue name with `RABBITMQ_QUEUE` retained as a backward-compatible alias. Updated the AMQP client to prefer the new variable name.

- **Cache Resilience**: Improved error handling in `getDemoCorpusWorkspaceIdAsync()` to avoid poisoning the cache with transient database errors, allowing subsequent requests to retry rather than permanently returning null.

## Implementation Details

- The MongoDB initialization now compares the current replica set member hostname with the desired configuration and reconfigures if needed using `rs.reconfig()` with force flag.
- The ping task in bootstrap is non-fatal and caught to prevent blocking the demo user creation flow.
- Cache updates only occur on definitive results (found or genuinely absent), not on transient errors.

https://claude.ai/code/session_01K4ZhUhXgGERcUKPakn83M5