### PR TITLE
fix: escape RS_HOST in mongodb-init command to prevent Docker Compose…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
           try {
             var s = rs.status();
             var cur = s.members[0].name;
-            var want = '${RS_HOST}:27017';
+            var want = '$${RS_HOST}:27017';
             if (cur !== want) {
               print('mongodb-init: reconfiguring RS member from ' + cur + ' to ' + want);
               var cfg = rs.conf();
@@ -75,7 +75,7 @@ services:
             }
             quit(0);
           } catch (e) {
-            rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: '${RS_HOST}:27017' }] });
+            rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: '$${RS_HOST}:27017' }] });
             quit(0);
           }
         "


### PR DESCRIPTION
… interpolation

${RS_HOST} in the command block was being consumed by Docker Compose variable interpolation before the container shell ran. Since RS_HOST is a bash-local variable (not a Docker Compose env var), Docker Compose substituted it as a blank string — causing rs.initiate() to receive host ':27017' instead of 'mongodb:27017'.

Change ${RS_HOST} to $${RS_HOST} in both occurrences inside the mongosh --eval string. Docker Compose renders $$ as a literal $, so bash inside the container receives ${RS_HOST} and expands it correctly from the variable set on the previous line: RS_HOST="${MONGODB_RS_HOST:-mongodb}".

Reproducer: the live deployment showed
  [WARNING]: The "RS_HOST" variable is not set. Defaulting to a blank string.
  service "mongodb-init" didn't complete successfully: exit 1

https://claude.ai/code/session_01K4ZhUhXgGERcUKPakn83M5